### PR TITLE
Agnostic http logger

### DIFF
--- a/http/src/main/scala/slogging/HttpLoggerFactory.scala
+++ b/http/src/main/scala/slogging/HttpLoggerFactory.scala
@@ -47,15 +47,6 @@ object HttpLoggerFactory {
                               clientId: String,
                               formatter: MessageFormatter)
 
-  sealed trait MessageLevel
-  object MessageLevel {
-    case object Trace extends MessageLevel
-    case object Debug extends MessageLevel
-    case object Info extends MessageLevel
-    case object Warn extends MessageLevel
-    case object Error extends MessageLevel
-  }
-
   class HttpLogger(config: HttpLoggerConfig) extends AbstractUnderlyingLogger {
     import config._
     @inline private final def log(level: MessageLevel, src: String, msg: String): Unit = log(level, src, msg, null)

--- a/http/src/main/scala/slogging/HttpLoggerFactory.scala
+++ b/http/src/main/scala/slogging/HttpLoggerFactory.scala
@@ -38,6 +38,42 @@ object HttpLoggerFactory {
     cause = if(cause==null) "" else cause.toString
   )
 
+  trait LoggerTemplate extends AbstractUnderlyingLogger {
+
+    @inline private final def log(level: MessageLevel, src: String, msg: String): Unit = log(level, src, msg, None)
+    @inline private final def log(level: MessageLevel, src: String, msg: String, args: Any*): Unit = log(level, src, String.format(msg, args), None)
+    @inline private final def log(level: MessageLevel, src: String, msg: String, cause: Option[Throwable]): Unit = logMessage(level, src, msg, cause)
+
+    final def error(source: String, message: String): Unit = log(MessageLevel.Error, source, message)
+    final def error(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Error, source, message, cause)
+    final def error(source: String, message: String, args: Any*): Unit = log(MessageLevel.Error, source, message, args)
+
+    final def warn(source: String, message: String): Unit = log(MessageLevel.Warn, source,message)
+    final def warn(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Warn, source, message, cause)
+    final def warn(source: String, message: String, args: Any*): Unit = log(MessageLevel.Warn, source, message, args)
+
+    final def info(source: String, message: String): Unit = log(MessageLevel.Info, source,message)
+    final def info(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Info, source, message, cause)
+    final def info(source: String, message: String, args: Any*): Unit = log(MessageLevel.Info, source, message, args)
+
+    final def debug(source: String, message: String): Unit = log(MessageLevel.Debug, source,message)
+    final def debug(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Debug, source, message, cause)
+    final def debug(source: String, message: String, args: Any*): Unit = log(MessageLevel.Debug, source, message, args)
+
+    final def trace(source: String, message: String): Unit = log(MessageLevel.Trace, source,message)
+    final def trace(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Trace, source, message, cause)
+    final def trace(source: String, message: String, args: Any*): Unit = log(MessageLevel.Trace, source, message, args)
+
+    /**
+      * @param level Message level
+      * @param name Logger name
+      * @param message Message content
+      * @param cause Optional cause
+      */
+    def logMessage(level: MessageLevel, name: String, message: String, cause: Option[Throwable]): Unit
+
+  }
+
   /**
    * @param url URL where logging messages are sent to
    * @param clientId A string identifying the client that sent the log message
@@ -47,32 +83,11 @@ object HttpLoggerFactory {
                               clientId: String,
                               formatter: MessageFormatter)
 
-  class HttpLogger(config: HttpLoggerConfig) extends AbstractUnderlyingLogger {
+  class HttpLogger(config: HttpLoggerConfig) extends LoggerTemplate {
     import config._
-    @inline private final def log(level: MessageLevel, src: String, msg: String): Unit = log(level, src, msg, null)
-    @inline private final def log(level: MessageLevel, src: String, msg: String, args: Any*): Unit = log(level, src, String.format(msg, args), null)
-    private final def log(level: MessageLevel, src: String, msg: String, cause: Throwable): Unit = sendMessage(url, formatter(clientId,level,src,msg,cause))
 
-
-    @inline final override def error(source: String, message: String): Unit = log(MessageLevel.Error, source,message)
-    @inline final override def error(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Error, source,message, cause)
-    @inline final override def error(source: String, message: String, args: Any*): Unit = log(MessageLevel.Error, source,message, args)
-
-    @inline final override def warn(source: String, message: String): Unit = log(MessageLevel.Warn, source,message)
-    @inline final override def warn(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Warn, source,message, cause)
-    @inline final override def warn(source: String, message: String, args: Any*): Unit = log(MessageLevel.Warn, source,message, args)
-
-    @inline final override def info(source: String, message: String): Unit = log(MessageLevel.Info, source,message)
-    @inline final override def info(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Info, source,message, cause)
-    @inline final override def info(source: String, message: String, args: Any*): Unit = log(MessageLevel.Info, source,message, args)
-
-    @inline final override def debug(source: String, message: String): Unit = log(MessageLevel.Debug, source,message)
-    @inline final override def debug(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Debug, source,message, cause)
-    @inline final override def debug(source: String, message: String, args: Any*): Unit = log(MessageLevel.Debug, source,message, args)
-
-    @inline final override def trace(source: String, message: String): Unit = log(MessageLevel.Trace, source,message)
-    @inline final override def trace(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Trace, source,message, cause)
-    @inline final override def trace(source: String, message: String, args: Any*): Unit = log(MessageLevel.Trace, source,message, args)
+    def logMessage(level: MessageLevel, name: String, message: String, cause: Option[Throwable]): Unit =
+      sendMessage(url, formatter(clientId, level, name, message, cause.orNull))
   }
 }
 

--- a/http/src/main/scala/slogging/HttpLoggerFactory.scala
+++ b/http/src/main/scala/slogging/HttpLoggerFactory.scala
@@ -28,11 +28,11 @@ object HttpLoggerFactory {
    *   <li>cause (may be null)</li>
    * </ul>
    */
-  type MessageFormatter = (String,String,String,String,Throwable) => js.Object
+  type MessageFormatter = (String,MessageLevel,String,String,Throwable) => js.Object
 
   val defaultFormatter: MessageFormatter = (clientId,level,name,msg,cause) => js.Dynamic.literal(
     clientId = clientId,
-    level = level,
+    level = level match { case MessageLevel.Trace => "trace" case MessageLevel.Debug => "debug" case MessageLevel.Info => "info" case MessageLevel.Warn => "warn" case MessageLevel.Error => "error" },
     name = name,
     msg = msg,
     cause = if(cause==null) "" else cause.toString
@@ -47,32 +47,41 @@ object HttpLoggerFactory {
                               clientId: String,
                               formatter: MessageFormatter)
 
+  sealed trait MessageLevel
+  object MessageLevel {
+    case object Trace extends MessageLevel
+    case object Debug extends MessageLevel
+    case object Info extends MessageLevel
+    case object Warn extends MessageLevel
+    case object Error extends MessageLevel
+  }
+
   class HttpLogger(config: HttpLoggerConfig) extends AbstractUnderlyingLogger {
     import config._
-    @inline private final def log(level: String, src: String, msg: String): Unit = log(level, src, msg, null)
-    @inline private final def log(level: String, src: String, msg: String, args: Any*): Unit = log(level, src, String.format(msg, args), null)
-    private final def log(level: String, src: String, msg: String, cause: Throwable): Unit = sendMessage(url, formatter(clientId,level,src,msg,cause))
+    @inline private final def log(level: MessageLevel, src: String, msg: String): Unit = log(level, src, msg, null)
+    @inline private final def log(level: MessageLevel, src: String, msg: String, args: Any*): Unit = log(level, src, String.format(msg, args), null)
+    private final def log(level: MessageLevel, src: String, msg: String, cause: Throwable): Unit = sendMessage(url, formatter(clientId,level,src,msg,cause))
 
 
-    @inline final override def error(source: String, message: String): Unit = log("error", source,message)
-    @inline final override def error(source: String, message: String, cause: Throwable): Unit = log("error", source,message, cause)
-    @inline final override def error(source: String, message: String, args: Any*): Unit = log("error", source,message, args)
+    @inline final override def error(source: String, message: String): Unit = log(MessageLevel.Error, source,message)
+    @inline final override def error(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Error, source,message, cause)
+    @inline final override def error(source: String, message: String, args: Any*): Unit = log(MessageLevel.Error, source,message, args)
 
-    @inline final override def warn(source: String, message: String): Unit = log("warn", source,message)
-    @inline final override def warn(source: String, message: String, cause: Throwable): Unit = log("warn", source,message, cause)
-    @inline final override def warn(source: String, message: String, args: Any*): Unit = log("warn", source,message, args)
+    @inline final override def warn(source: String, message: String): Unit = log(MessageLevel.Warn, source,message)
+    @inline final override def warn(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Warn, source,message, cause)
+    @inline final override def warn(source: String, message: String, args: Any*): Unit = log(MessageLevel.Warn, source,message, args)
 
-    @inline final override def info(source: String, message: String): Unit = log("info", source,message)
-    @inline final override def info(source: String, message: String, cause: Throwable): Unit = log("info", source,message, cause)
-    @inline final override def info(source: String, message: String, args: Any*): Unit = log("info", source,message, args)
+    @inline final override def info(source: String, message: String): Unit = log(MessageLevel.Info, source,message)
+    @inline final override def info(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Info, source,message, cause)
+    @inline final override def info(source: String, message: String, args: Any*): Unit = log(MessageLevel.Info, source,message, args)
 
-    @inline final override def debug(source: String, message: String): Unit = log("debug", source,message)
-    @inline final override def debug(source: String, message: String, cause: Throwable): Unit = log("debug", source,message, cause)
-    @inline final override def debug(source: String, message: String, args: Any*): Unit = log("debug", source,message, args)
+    @inline final override def debug(source: String, message: String): Unit = log(MessageLevel.Debug, source,message)
+    @inline final override def debug(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Debug, source,message, cause)
+    @inline final override def debug(source: String, message: String, args: Any*): Unit = log(MessageLevel.Debug, source,message, args)
 
-    @inline final override def trace(source: String, message: String): Unit = log("trace", source,message)
-    @inline final override def trace(source: String, message: String, cause: Throwable): Unit = log("trace", source,message, cause)
-    @inline final override def trace(source: String, message: String, args: Any*): Unit = log("trace", source,message, args)
+    @inline final override def trace(source: String, message: String): Unit = log(MessageLevel.Trace, source,message)
+    @inline final override def trace(source: String, message: String, cause: Throwable): Unit = log(MessageLevel.Trace, source,message, cause)
+    @inline final override def trace(source: String, message: String, args: Any*): Unit = log(MessageLevel.Trace, source,message, args)
   }
 }
 

--- a/http/src/main/scala/slogging/HttpLoggerFactory.scala
+++ b/http/src/main/scala/slogging/HttpLoggerFactory.scala
@@ -49,8 +49,8 @@ object HttpLoggerFactory {
 
   class HttpLogger(config: HttpLoggerConfig) extends AbstractUnderlyingLogger {
     import config._
-    @inline private final def log(level: String, src: String, msg: String): Unit = log(level,msg,null)
-    @inline private final def log(level: String, src: String, msg: String, args: Any*): Unit = log(level, String.format(msg, args), null)
+    @inline private final def log(level: String, src: String, msg: String): Unit = log(level, src, msg, null)
+    @inline private final def log(level: String, src: String, msg: String, args: Any*): Unit = log(level, src, String.format(msg, args), null)
     private final def log(level: String, src: String, msg: String, cause: Throwable): Unit = sendMessage(url, formatter(clientId,level,src,msg,cause))
 
 

--- a/shared/src/main/scala/slogging/loggerFactory.scala
+++ b/shared/src/main/scala/slogging/loggerFactory.scala
@@ -114,6 +114,16 @@ object LogLevel extends Enumeration {
   val TRACE = Value(5)
 }
 
+/** Level of a given logging message */
+sealed trait MessageLevel
+object MessageLevel {
+  case object Trace extends MessageLevel
+  case object Debug extends MessageLevel
+  case object Info extends MessageLevel
+  case object Warn extends MessageLevel
+  case object Error extends MessageLevel
+}
+
 object PrintLogger extends AbstractUnderlyingLogger {
   import LoggingUtils.formatMessage
   private var _printLoggerName: Boolean = true


### PR DESCRIPTION
These refactorings make it easier to implement a custom HTTP logger. Basically I introduced a `LoggerTemplate` which has only one abstract method (instead of the 12 methods that you have to implement when you implement `AbstractUnderlyingLogger`.

I think this `LoggerTemplate` could superseed the actual `AbstractUnderlyingLogger` at some point.
